### PR TITLE
Fix: Historical OHLCV page index

### DIFF
--- a/src/exchanges/binance/binance.exchange.ts
+++ b/src/exchanges/binance/binance.exchange.ts
@@ -405,7 +405,7 @@ export class Binance extends BaseExchange {
     const totalPages = Math.ceil(requiredCandles / KLINES_LIMIT);
 
     const results = await mapSeries(
-      times(totalPages, (i) => i + 1),
+      times(totalPages, (i) => i),
       async (page) => {
         const currentLimit = Math.min(
           requiredCandles - page * KLINES_LIMIT,

--- a/src/exchanges/bybit/bybit.exchange.ts
+++ b/src/exchanges/bybit/bybit.exchange.ts
@@ -351,7 +351,7 @@ export class Bybit extends BaseExchange {
     const totalPages = Math.ceil(requiredCandles / KLINES_LIMIT);
 
     const results = await mapSeries(
-      times(totalPages, (i) => i + 1),
+      times(totalPages, (i) => i),
       async (page) => {
         const currentLimit = Math.min(
           requiredCandles - page * KLINES_LIMIT,


### PR DESCRIPTION
Pages were being indexed from 1 instead of 0 which was causing errors in the currentLimit calculation