### PR TITLE
Binance ws URL depreceated 

### DIFF
--- a/src/exchanges/binance/binance.types.ts
+++ b/src/exchanges/binance/binance.types.ts
@@ -17,7 +17,7 @@ export const BASE_WS_URL = {
     testnet: 'wss://stream.binancefuture.com/ws',
   },
   private: {
-    livenet: 'wss://fstream-auth.binance.com/ws',
+    livenet: 'wss://fstream.binance.com/ws',
     testnet: 'wss://stream.binancefuture.com/ws',
   },
 };

--- a/src/exchanges/binance/binance.ws-private.ts
+++ b/src/exchanges/binance/binance.ws-private.ts
@@ -19,9 +19,7 @@ export class BinancePrivateWebsocket extends BaseWebSocket<BinanceExchange> {
       const key = this.parent.options.testnet ? 'testnet' : 'livenet';
       const base = BASE_WS_URL.private[key];
 
-      const url = this.parent.options.testnet
-        ? `${base}/${listenKey}`
-        : `${base}/${listenKey}?listenKey=${listenKey}`;
+      const url = `${base}/${listenKey}`;
 
       this.ws = new WebSocket(url);
       this.ws.addEventListener('message', this.onMessage);


### PR DESCRIPTION
 wss://fstream-auth.binance.com not working anymore  need to change also how we build URL 
 
 
 BINANCE DOCS:
 
 
Base Url 1: wss://fstream.binance.com
User Data Streams are accessed at /ws/<listenKey>
Example: wss://fstream.binance.com/ws/XaEAKTsQSRLZAGH9tuIu37plSRsdjmlAVBoNYPUITlTAko1WI22PgmBMpI1rS8Yh
Base Url 2: wss://fstream-auth.binance.com
User Data Streams are accessed at /ws/<listenKey>?listenKey=<validateListenKey>
<validateListenKey> must be a valid listenKey when you establish a connection
Example:
wss://fstream-auth.binance.com/ws/XaEAKTsQSRLZAGH9tuIu37plSRsdjmlAVBoNYPUITlTAko1WI22PgmBMpI1rS8Yh？listenKey=XaEAKTsQSRLZAGH9tuIu37plSRsdjmlAVBoNYPUITlTAko1WI22PgmBMpI1rS8Yh