### PR TITLE
Remove Expired Orders from store

### DIFF
--- a/src/exchanges/binance/binance.ws-private.ts
+++ b/src/exchanges/binance/binance.ws-private.ts
@@ -88,7 +88,7 @@ export class BinancePrivateWebsocket extends BaseWebSocket<BinanceExchange> {
         });
       }
 
-      if (data.X === 'CANCELED' || data.X === 'FILLED') {
+      if (data.X === 'CANCELED' || data.X === 'FILLED' || data.X === 'EXPIRED') {
         this.store.removeOrder({ id: data.c });
       }
     });


### PR DESCRIPTION
we need to remove expired ro orders because we can't have more than 100% of pos in ro orders so they got expired